### PR TITLE
Add support for WebGL

### DIFF
--- a/Assets/Scripts/DataSource/FileSystem.cs
+++ b/Assets/Scripts/DataSource/FileSystem.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
+using System.Text;
 using System.Threading;
 using CAFU.Data.Repository;
 using UniRx.Async;
+using UnityEngine;
 
 namespace CAFU.Data.DataSource
 {
@@ -13,6 +15,12 @@ namespace CAFU.Data.DataSource
             if (Exists(uri))
             {
                 throw new InvalidOperationException($"File `{GetUnescapedAbsolutePath(uri)}' has already exists.");
+            }
+
+            if (Application.platform == RuntimePlatform.WebGLPlayer)
+            {
+                PlayerPrefs.SetString(GetUnescapedAbsolutePath(uri), Encoding.UTF8.GetString(data ?? new byte[0]));
+                return;
             }
 
             CreateDirectoryIfNeeded(uri);
@@ -31,6 +39,11 @@ namespace CAFU.Data.DataSource
                 throw new FileNotFoundException($"File `{GetUnescapedAbsolutePath(uri)}' does not found.");
             }
 
+            if (Application.platform == RuntimePlatform.WebGLPlayer)
+            {
+                return Encoding.UTF8.GetBytes(PlayerPrefs.GetString(GetUnescapedAbsolutePath(uri)));
+            }
+
             using (var stream = new FileStream(GetUnescapedAbsolutePath(uri), FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
             {
                 var data = new byte[stream.Length];
@@ -44,6 +57,12 @@ namespace CAFU.Data.DataSource
             if (!Exists(uri))
             {
                 throw new FileNotFoundException($"File `{GetUnescapedAbsolutePath(uri)}' does not found.");
+            }
+
+            if (Application.platform == RuntimePlatform.WebGLPlayer)
+            {
+                PlayerPrefs.SetString(GetUnescapedAbsolutePath(uri), Encoding.UTF8.GetString(data ?? new byte[0]));
+                return;
             }
 
             using (var stream = new FileStream(GetUnescapedAbsolutePath(uri), FileMode.Truncate, FileAccess.ReadWrite, FileShare.ReadWrite))
@@ -60,12 +79,20 @@ namespace CAFU.Data.DataSource
                 throw new FileNotFoundException($"File `{GetUnescapedAbsolutePath(uri)}' does not found.");
             }
 
+            if (Application.platform == RuntimePlatform.WebGLPlayer)
+            {
+                PlayerPrefs.DeleteKey(GetUnescapedAbsolutePath(uri));
+                return;
+            }
+
             File.Delete(GetUnescapedAbsolutePath(uri));
         }
 
         public bool Exists(Uri uri)
         {
-            return File.Exists(GetUnescapedAbsolutePath(uri));
+            return Application.platform == RuntimePlatform.WebGLPlayer
+                ? PlayerPrefs.HasKey(GetUnescapedAbsolutePath(uri))
+                : File.Exists(GetUnescapedAbsolutePath(uri));
         }
 
         internal static void CreateDirectoryIfNeeded(Uri uri)
@@ -94,6 +121,12 @@ namespace CAFU.Data.DataSource
                 throw new InvalidOperationException($"File `{FileSystem.GetUnescapedAbsolutePath(uri)}' has already exists.");
             }
 
+            if (Application.platform == RuntimePlatform.WebGLPlayer)
+            {
+                PlayerPrefs.SetString(FileSystem.GetUnescapedAbsolutePath(uri), Encoding.UTF8.GetString(data ?? new byte[0]));
+                return;
+            }
+
             FileSystem.CreateDirectoryIfNeeded(uri);
 
             using (var stream = new FileStream(FileSystem.GetUnescapedAbsolutePath(uri), FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite))
@@ -110,6 +143,11 @@ namespace CAFU.Data.DataSource
             if (!await ExistsAsync(uri, cancellationToken))
             {
                 throw new FileNotFoundException($"File `{FileSystem.GetUnescapedAbsolutePath(uri)}' does not found.");
+            }
+
+            if (Application.platform == RuntimePlatform.WebGLPlayer)
+            {
+                return Encoding.UTF8.GetBytes(PlayerPrefs.GetString(FileSystem.GetUnescapedAbsolutePath(uri)));
             }
 
             using (var stream = new FileStream(FileSystem.GetUnescapedAbsolutePath(uri), FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
@@ -129,6 +167,12 @@ namespace CAFU.Data.DataSource
                 throw new FileNotFoundException($"File `{FileSystem.GetUnescapedAbsolutePath(uri)}' does not found.");
             }
 
+            if (Application.platform == RuntimePlatform.WebGLPlayer)
+            {
+                PlayerPrefs.SetString(FileSystem.GetUnescapedAbsolutePath(uri), Encoding.UTF8.GetString(data ?? new byte[0]));
+                return;
+            }
+
             using (var stream = new FileStream(FileSystem.GetUnescapedAbsolutePath(uri), FileMode.Truncate, FileAccess.ReadWrite, FileShare.ReadWrite))
             {
                 data = data ?? new byte[0];
@@ -145,12 +189,23 @@ namespace CAFU.Data.DataSource
                 throw new FileNotFoundException($"File `{FileSystem.GetUnescapedAbsolutePath(uri)}' does not found.");
             }
 
+            if (Application.platform == RuntimePlatform.WebGLPlayer)
+            {
+                PlayerPrefs.DeleteKey(FileSystem.GetUnescapedAbsolutePath(uri));
+                return;
+            }
+
             await UniTask.Run(() => File.Delete(FileSystem.GetUnescapedAbsolutePath(uri)));
         }
 
         public async UniTask<bool> ExistsAsync(Uri uri, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            if (Application.platform == RuntimePlatform.WebGLPlayer)
+            {
+                return PlayerPrefs.HasKey(FileSystem.GetUnescapedAbsolutePath(uri));
+            }
 
             return await UniTask.FromResult(File.Exists(FileSystem.GetUnescapedAbsolutePath(uri)));
         }


### PR DESCRIPTION
- WebGL の場合は IndexedDB に任せるために PlayerPrefs を用いる
    - 無駄な変換が挟まってしまうが一旦許容する
- PlayerPrefs のキーにはファイル名を用いる